### PR TITLE
Change type of settings with sensitive data to secure string VirtoCommerce/vc-platform#894

### DIFF
--- a/PaymentMethods.Tests/PaypalCheckoutTests.cs
+++ b/PaymentMethods.Tests/PaypalCheckoutTests.cs
@@ -114,11 +114,13 @@ namespace PaymentMethods.Tests
             settings.Add(new SettingEntry
             {
                 Name = "Paypal.ExpressCheckout.APIPassword",
+                ValueType = SettingValueType.SecureString,
                 Value = "XMDRC63XDNDQPXAZ"
             });
             settings.Add(new SettingEntry
             {
                 Name = "Paypal.ExpressCheckout.APISignature",
+                ValueType = SettingValueType.SecureString,
                 Value = "AiPC9BjkCyDFQXbSkoZcgqH3hpacAddFA7jQMnRzruCFYMSKx38TE0pt"
             });
             settings.Add(new SettingEntry

--- a/Paypal.ExpressCheckout/module.manifest
+++ b/Paypal.ExpressCheckout/module.manifest
@@ -57,13 +57,13 @@
             </setting>
             <setting>
                 <name>Paypal.ExpressCheckout.APIPassword</name>
-                <valueType>string</valueType>
+                <valueType>securestring</valueType>
                 <title>API password</title>
                 <description>Merchant api password credential</description>
             </setting>
             <setting>
                 <name>Paypal.ExpressCheckout.APISignature</name>
-                <valueType>string</valueType>
+                <valueType>securestring</valueType>
                 <title>API signature</title>
                 <description>Merchant api signature credential</description>
             </setting>


### PR DESCRIPTION
Tests fails even without this changes because of outdated nuget dependencies for Order module  (db migration issue)